### PR TITLE
Fig 'restart: always'

### DIFF
--- a/fig.yml
+++ b/fig.yml
@@ -4,5 +4,7 @@ web:
    - mongo
   ports:
    - "3800:3800"
+  restart: always
 mongo:
   image: mongo:2.7.5
+  restart: always


### PR DESCRIPTION
Feature isn't yet supported by any of the released versions of Fig. Fig must be installed from the repository...

``` bash
git clone git@github.com:docker/fig.git
cd fig
./script/build-linux # ./scripts/build-osx
sudo cp ./dist/fig-Linux-x86_64 /usr/local/bin/fig
sudo chmod +x /usr/local/bin/fig
```
